### PR TITLE
Promote time_start and time_end date range to ManoloBaseSpider

### DIFF
--- a/manolo_scraper/manolo_scraper/spiders/congreso.py
+++ b/manolo_scraper/manolo_scraper/spiders/congreso.py
@@ -1,7 +1,6 @@
 import re
 import math
 import datetime
-from datetime import timedelta
 
 from scrapy import FormRequest, Request
 
@@ -14,29 +13,21 @@ from ..utils import make_hash
 
 class CongresoSpider(ManoloBaseSpider):
     name = 'congreso'
-    allowed_domains = ["regvisitas.congreso.gob.pe"]
+    allowed_domains = ['regvisitas.congreso.gob.pe']
     NUMBER_OF_PAGES_PER_PAGE = 10
 
-    def start_requests(self):
-        d1 = datetime.datetime.strptime(self.date_start, '%Y-%m-%d').date()
-        d2 = datetime.datetime.strptime(self.date_end, '%Y-%m-%d').date()
-        delta = d2 - d1
+    def initial_request(self, date):
+        date_str = date.strftime("%d/%m/%Y")
 
-        for i in range(delta.days + 1):
-            date = d1 + timedelta(days=i)
-            date_str = date.strftime("%d/%m/%Y")
-
-            print("SCRAPING: %s" % date_str)
-
-            # This initial request always hit the current page of the date.
-            request = Request(url="http://regvisitas.congreso.gob.pe/regvisitastransparencia/",
-                              meta={
-                                  'date': date_str,
+        # This initial request always hit the current page of the date.
+        request = Request(url='http://regvisitas.congreso.gob.pe/regvisitastransparencia/',
+                          meta={
+                              'date': date_str,
                               },
-                              dont_filter=True,
-                              callback=self.parse_initial_request)
+                          dont_filter=True,
+                          callback=self.parse_initial_request)
 
-            yield request
+        return request
 
     def parse_initial_request(self, response):
         date = response.meta['date']

--- a/manolo_scraper/manolo_scraper/spiders/defensa.py
+++ b/manolo_scraper/manolo_scraper/spiders/defensa.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import datetime
-import logging
 
 import scrapy
 
@@ -15,21 +14,15 @@ class DefensaSpider(ManoloBaseSpider):
     allowed_domains = ['mindef.gob.pe']
     base_url = 'http://www.mindef.gob.pe/visitas/qryvisitas.php'
 
-    def start_requests(self):
-        d1 = datetime.datetime.strptime(self.date_start, '%Y-%m-%d').date()
-        d2 = datetime.datetime.strptime(self.date_end, '%Y-%m-%d').date()
-        delta = d2 - d1
+    def initial_request(self, date):
+        date_str = date.strftime("%d/%m/%Y")
 
-        for i in range(delta.days + 1):
-            date = d1 + datetime.timedelta(days=i)
-            date_str = date.strftime("%d/%m/%Y")
-            logging.info("SCRAPING: {}".format(date_str))
+        params = {'fechaqry': date_str}
 
-            params = {'fechaqry': date_str}
-            yield scrapy.FormRequest(url=self.base_url, formdata=params,
-                                     meta={'date': date_str},
-                                     dont_filter=True,
-                                     callback=self.after_post)
+        return scrapy.FormRequest(url=self.base_url, formdata=params,
+                                 meta={'date': date_str},
+                                 dont_filter=True,
+                                 callback=self.after_post)
 
     def after_post(self, response):
         # send requests based on pagination
@@ -45,7 +38,6 @@ class DefensaSpider(ManoloBaseSpider):
                                      callback=self.parse)
 
     def parse(self, response):
-        logging.info("PARSED URL {}".format(response.url))
 
         date_obj = datetime.datetime.strptime(response.meta['date'], '%d/%m/%Y')
         date = datetime.datetime.strftime(date_obj, '%Y-%m-%d')

--- a/manolo_scraper/manolo_scraper/spiders/inpe.py
+++ b/manolo_scraper/manolo_scraper/spiders/inpe.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import datetime
-from datetime import timedelta
 
 import scrapy
 
@@ -18,34 +17,18 @@ class INPESpider(ManoloBaseSpider):
         'visitasadm.inpe.gob.pe'
     ]
 
-    def start_requests(self):
-        """
-        Get starting date to scrape from argument
-        e.g.: 2010-02-21
+    def initial_request(self, date):
+        date_str = date.strftime('%d/%m/%Y')
+        request = scrapy.FormRequest('http://visitasadm.inpe.gob.pe/VisitasadmInpe/Controller',
+                                     formdata={
+                                         'vis_fec_ing': date_str
+                                     },
+                                     meta={
+                                         'date': date_str
+                                     },
+                                     callback=self.parse)
 
-        :return: set of URLs
-        """
-        d1 = datetime.datetime.strptime(self.date_start, '%Y-%m-%d').date()
-        d2 = datetime.datetime.strptime(self.date_end, '%Y-%m-%d').date()
-        # range to fetch
-        delta = d2 - d1
-
-        for i in range(delta.days + 1):
-            date = d1 + timedelta(days=i)
-            date_str = date.strftime('%d/%m/%Y')
-
-            print("SCRAPING: %s" % date)
-
-            request = scrapy.FormRequest('http://visitasadm.inpe.gob.pe/VisitasadmInpe/Controller',
-                                         formdata={
-                                             'vis_fec_ing': date_str
-                                         },
-                                         meta={
-                                            'date': date_str
-                                         },
-                                         callback=self.parse)
-
-            yield request
+        return request
 
     def parse(self, response):
 
@@ -53,9 +36,6 @@ class INPESpider(ManoloBaseSpider):
         date = datetime.datetime.strftime(date_obj, '%Y-%m-%d')
 
         rows = response.xpath('//tr')
-
-        # inspect_response(response, self)
-        # open_in_browser(response)
 
         for row in rows:
 

--- a/manolo_scraper/manolo_scraper/spiders/minem.py
+++ b/manolo_scraper/manolo_scraper/spiders/minem.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import datetime
-from datetime import timedelta
 import math
 
 import scrapy
@@ -19,25 +18,12 @@ class MinemSpider(ManoloBaseSpider):
 
     NUMBER_OF_PAGES_PER_PAGE = 20
 
-    def start_requests(self):
-        """
-        Get starting date to scrape from our database
+    def initial_request(self, date):
+        date_str = date.strftime("%d/%m/%Y")
 
-        :return: set of URLs
-        """
-        d1 = datetime.datetime.strptime(self.date_start, '%Y-%m-%d').date()
-        d2 = datetime.datetime.strptime(self.date_end, '%Y-%m-%d').date()
-        # range to fetch
-        delta = d2 - d1
+        request = self.make_form_request(date_str, self.parse_pages, 1)
 
-        for i in range(delta.days + 1):
-            my_date = d1 + timedelta(days=i)
-            my_date_str = my_date.strftime("%d/%m/%Y")
-            print("SCRAPING: %s" % my_date_str)
-
-            request = self.make_form_request(my_date_str, self.parse_pages, 1)
-
-            yield request
+        return request
 
     def parse_pages(self, response):
         total_of_records = response.css('#HID_CantidadRegistros').xpath('./@value').extract_first(default=1)

--- a/manolo_scraper/manolo_scraper/spiders/minsa.py
+++ b/manolo_scraper/manolo_scraper/spiders/minsa.py
@@ -1,6 +1,4 @@
 import datetime
-from datetime import timedelta
-
 import re
 
 from scrapy import FormRequest, Request
@@ -19,24 +17,17 @@ class MinsaSpider(ManoloBaseSpider):
     MORE_PAGES_SYMBOL = '...'
     NUMBER_OF_PAGE_REGEX = r'Page\$(\w+)'
 
-    def start_requests(self):
-        d1 = datetime.datetime.strptime(self.date_start, '%Y-%m-%d').date()
-        d2 = datetime.datetime.strptime(self.date_end, '%Y-%m-%d').date()
-        delta = d2 - d1
+    def initial_request(self, date):
+        date_str = date.strftime(self.REQUEST_DATE_FORMAT)
 
-        for i in range(delta.days + 1):
-            date = d1 + timedelta(days=i)
-            date_str = date.strftime(self.REQUEST_DATE_FORMAT)
-            print("SCRAPING: %s" % date_str)
+        request = Request(url='http://intranet5.minsa.gob.pe/RegVisitasCons/listado.aspx',
+                          dont_filter=True,
+                          callback=self.parse_initial_request,
+                          )
 
-            request = Request(url='http://intranet5.minsa.gob.pe/RegVisitasCons/listado.aspx',
-                              dont_filter=True,
-                              callback=self.parse_initial_request,
-            )
+        request.meta['date'] = date_str
 
-            request.meta['date'] = date_str
-
-            yield request
+        return request
 
     def parse_initial_request(self, response):
         date_str = response.meta['date']

--- a/manolo_scraper/manolo_scraper/spiders/produce.py
+++ b/manolo_scraper/manolo_scraper/spiders/produce.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import datetime
-from datetime import timedelta
 
 import scrapy
 
@@ -14,28 +13,19 @@ class ProduceSpider(ManoloBaseSpider):
     name = 'produce'
     allowed_domains = ['http://www2.produce.gob.pe']
 
-    def start_requests(self):
-        d1 = datetime.datetime.strptime(self.date_start, '%Y-%m-%d').date()
-        d2 = datetime.datetime.strptime(self.date_end, '%Y-%m-%d').date()
+    def initial_request(self, date):
+        date_str = date.strftime("%d/%m/%Y")
+        request = scrapy.FormRequest('http://www2.produce.gob.pe/produce/transparencia/visitas/',
+                                     formdata={
+                                         'desFecha': date_str,
+                                         'desFechaF': date_str,
+                                         'buscar': 'Consultar'
+                                     },
+                                     callback=self.parse)
 
-        delta = d2 - d1
+        request.meta['date'] = date_str
 
-        for i in range(delta.days + 1):
-            date = d1 + timedelta(days=i)
-            date_str = date.strftime('%d/%m/%Y')
-
-            print('SCRAPING: %s' % date_str)
-
-            request = scrapy.FormRequest('http://www2.produce.gob.pe/produce/transparencia/visitas/',
-                                         formdata={
-                                             'desFecha': date_str,
-                                             'desFechaF': date_str,
-                                             'buscar': 'Consultar'
-                                         },
-                                         callback=self.parse)
-
-            request.meta['date'] = date_str
-            yield request
+        return request
 
     def parse(self, response):
         date_obj = datetime.datetime.strptime(response.meta['date'], '%d/%m/%Y')

--- a/manolo_scraper/tests/test_manolobase_spider.py
+++ b/manolo_scraper/tests/test_manolobase_spider.py
@@ -1,5 +1,7 @@
 import unittest
+from datetime import date
 
+from exceptions import NotImplementedError
 from scrapy import exceptions
 
 from manolo_scraper.spiders.spiders import ManoloBaseSpider
@@ -10,3 +12,9 @@ class TestManoloBaseSpider(unittest.TestCase):
     def test_start_date_and_end_date(self):
         with self.assertRaises(exceptions.UsageError):
             ManoloBaseSpider(date_start='2015-08-20', date_end='2015-08-17', name='manolo')
+
+    def test_initial_request(self):
+        with self.assertRaises(NotImplementedError):
+            spider = ManoloBaseSpider(name='manolo')
+            today = date.today()
+            spider.initial_request(today)


### PR DESCRIPTION
Now all the spiders must implement `initial_request` method. This method handles the date range logic.

For example in CongresoSpider the `initial_request` method looks like

``` python
    def initial_request(self, date):
        date_str = date.strftime("%d/%m/%Y")

        # This initial request always hit the current page of the date.
        request = Request(url='http://regvisitas.congreso.gob.pe/regvisitastransparencia/',
                          meta={
                              'date': date_str,
                              },
                          dont_filter=True,
                          callback=self.parse_initial_request)

        return request
```
